### PR TITLE
fixed the shouldcomponentupdate instructions in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The only change that registers for our Timer components is the change in
 `this.state.time`. This means that instead of including this:
 
 ```js
-shouldComponentUpdate() {
+shouldComponentUpdate(nextProps, nextState) {
   if (this.state.time === nextState.time) {
     return false
   }


### PR DESCRIPTION
The instructions in the readme will cause a compilation error, as the shouldComponentUpdate method will not have access to nextState unless it is declared as an argument